### PR TITLE
modify to capture impacts to bundle vote

### DIFF
--- a/fip-0010.md
+++ b/fip-0010.md
@@ -5,15 +5,15 @@ status: Accepted
 type: Functionality
 author: Ed Rotthoff <ed@dapix.io>; Pawel Mastalerz <pawel@dapix.io>
 created: 2020-06-07
-updated: 2020-06-11
+updated: 2020-06-22
 ---
 
 ## Abstract
-This FIP implements a redesign of the fee voting and fee computation in the FIO Protocol. Specifically:
+This FIP implements a redesign of the fee voting and computation, and bundled transaction voting and computation in the FIO Protocol. Specifically:
 * Fee computation will be removed from onblock and from [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model) and [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model) and attached to a dedicated action/endpoint.
-* Top 42 block producers will be permitted to vote for fees.
-* A fee will be collected whenever a [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model) and [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model) is executed.
-* Only votes of top 21 block producers will be used to compute the fees. 
+* Top 42 block producers will be permitted to vote for fees and bundled transactions.
+* A fee will be collected whenever a [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model), [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model) is executed, and [bundlevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-bundled-transaction/submit-bundled-transaction-model)
+* Only votes of top 21 block producers will be used to compute the fees and bundled transactions.
 
 Proposed new actions:
 |Action|Endpoint|Description|
@@ -28,7 +28,7 @@ Modified actions:
 |bundlevote|submit_bundled_transaction|Can now be called by top 42 BP. Fee is added.|
 
 ## Motivation
-The FIO Protocol was designed to enable top 21 producers to vote on protocol fees via [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model) and [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model).
+The FIO Protocol was designed to enable top 21 producers to vote on protocol fees and bundled transactions via [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model), and [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model).
 
 The [computation of fees](https://developers.fioprotocol.io/fio-chain/bp#setting-fees) occurs after every [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model) or [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model). The fees are also recomputed in the onblock every 126 blocks.
 
@@ -259,22 +259,23 @@ Modify the action to:
 ```
 #### [bundlevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-bundled-transaction/submit-bundled-transaction)
 Modified to be callable by top 42 BP, and charge a fee.
-##### New fee: add submit_bundled_transaction fee: 100000000, not eligible for bundled transactions
+##### New fee: add submit_bundled_transaction fee: 400000000, not eligible for bundled transactions
 ##### Request
 |Parameter|Required|Format|Definition|
 |---|---|---|---|
-|bundled_transactions|Yes|int|vote for number of bundled tx|
+|bundled_transactions|Yes|int|Number of bundled transactions which should be included with every FIO Address.|
 |max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
 |actor|Yes|12 character string|Valid actor of signer|
 ##### Processing
 Modify the action to:
 * Allow only top 42 block producers to call it.
 * Charge a fee.
+* Record value
 ##### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|
 |Not a BP|Actor is not a top 42 BP.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Not a top 42 BP."|
-|Not positive|voted number of bundled transactions value is not positive|400|"value"|Value sent in, e.g. "-1"|"Value has to be positive."|
+|Not positive|bundled_transactions is not positive|400|"bundled_transactions"|Value sent in, e.g. "-1"|"Value has to be positive."|
 |Too soon since last call|Call was made less than 120 seconds since last call.|400|||"Too soon since last call."|
 |Invalid fee value|max_fee format is not valid|400|"max_fee"|Value sent in, e.g. "-100"|"Invalid fee value"|
 |Insufficient funds to cover fee|Account does not have enough funds to cover fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Insufficient funds to cover fee"|
@@ -290,6 +291,8 @@ Modify the action to:
 	"status": "OK",
 	"fee_collected": 2000000000
 }
+```
+
 ## Implementation
 ### Endpoint updates
 none. using binary extensions ensures backwards compatibilty.

--- a/fip-0010.md
+++ b/fip-0010.md
@@ -23,8 +23,9 @@ Proposed new actions:
 Modified actions:
 |Action|Endpoint|Description|
 |---|---|---|
-|setfeevote|set_fee_vote|Can now be called by any BP. Fee is added. Fee computation removed from this action.|
-|setfeemult|set_fee_multiplier|Can now be called by any BP. Fee is added. Fee computation removed from this action.|
+|setfeevote|set_fee_vote|Can now be called by top 42 BP. Fee is added. Fee computation removed from this action.|
+|setfeemult|set_fee_multiplier|Can now be called by top 42 BP. Fee is added. Fee computation removed from this action.|
+|bundlevote|submit_bundled_transaction|Can now be called by top 42 BP. Fee is added.|
 
 ## Motivation
 The FIO Protocol was designed to enable top 21 producers to vote on protocol fees via [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model) and [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model).
@@ -72,7 +73,7 @@ Empty
 
 ### Modifications to existing actions
 #### [setfeevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-ratios/submit-fee-ratios-model)
-Modified to use new table, be callable by any BP, and charge a fee.
+Modified to be callable by top 42 BP, and charge a fee.
 ##### New fee: add submit_fee_ratios fee: 1000000000, not eligible for bundled transactions
 ##### Request
 |Group|Parameter|Required|Format|Definition|
@@ -221,7 +222,7 @@ Modify the existing action to:
 }
 ```
 #### [setfeemult](https://developers.fioprotocol.io/api/api-spec/reference/submit-fee-multiplier/submit-fee-multiplier-model)
-Modified to use new table, be callable by any BP, and charge a fee.
+Modified to be callable by top 42 BP, and charge a fee.
 ##### New fee: add submit_fee_multiplier fee: 400000000, not eligible for bundled transactions
 ##### Request
 |Parameter|Required|Format|Definition|
@@ -256,7 +257,39 @@ Modify the action to:
 	"fee_collected": 2000000000
 }
 ```
-
+#### [bundlevote](https://developers.fioprotocol.io/api/api-spec/reference/submit-bundled-transaction/submit-bundled-transaction)
+Modified to be callable by top 42 BP, and charge a fee.
+##### New fee: add submit_bundled_transaction fee: 100000000, not eligible for bundled transactions
+##### Request
+|Parameter|Required|Format|Definition|
+|---|---|---|---|
+|bundled_transactions|Yes|int|vote for number of bundled tx|
+|max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
+|actor|Yes|12 character string|Valid actor of signer|
+##### Processing
+Modify the action to:
+* Allow only top 42 block producers to call it.
+* Charge a fee.
+##### Exception handling
+|Error condition|Trigger|Type|fields:name|fields:value|Error message|
+|---|---|---|---|---|---|
+|Not a BP|Actor is not a top 42 BP.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Not a top 42 BP."|
+|Not positive|voted number of bundled transactions value is not positive|400|"value"|Value sent in, e.g. "-1"|"Value has to be positive."|
+|Too soon since last call|Call was made less than 120 seconds since last call.|400|||"Too soon since last call."|
+|Invalid fee value|max_fee format is not valid|400|"max_fee"|Value sent in, e.g. "-100"|"Invalid fee value"|
+|Insufficient funds to cover fee|Account does not have enough funds to cover fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Insufficient funds to cover fee"|
+|Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
+##### Response
+|Parameter|Format|Definition|
+|---|---|---|
+|status|String|OK if successful|
+|fee_collected|Int|Amount of SUFs collected as fee|
+###### Example
+```
+{
+	"status": "OK",
+	"fee_collected": 2000000000
+}
 ## Implementation
 ### Endpoint updates
 none. using binary extensions ensures backwards compatibilty.


### PR DESCRIPTION
this PR fixes a couple of details on set fee vote and set fee multiplier, and captures impacts to bundle vote. Bundle vote will be modified and another round of QA will be performed.