### PR TITLE
specify the validation of the locking period durations

### DIFF
--- a/fip-0006.md
+++ b/fip-0006.md
@@ -112,7 +112,7 @@ The fee will be: (1 90-day period in 259200 seconds * 300000000) = 600000000, th
 	* Require auth of the actor.
 	* Ensure payee public key does not hash down to existing account.
 	* Lock period verification:
-		* Minimum of 1 period. Maximum: 365 **(pending performance validation)**.
+		* Minimum of 1 period. Maximum: 50.
                        "Invalid number of unlock periods"
 		* verify 3 digit precision of percentage for each period.
            		"Invalid precision for percentage in unlock periods"

--- a/fip-0006.md
+++ b/fip-0006.md
@@ -120,6 +120,9 @@ The fee will be: (1 90-day period in 259200 seconds * 300000000) = 600000000, th
 			"Invalid total percentage for unlock periods"
 		* Duration in each period is greater than 0.
 			"Invalid duration value in unlock periods"
+               * Validate that all values of duration are ordered from smallest to largest 
+                 verify that each lock period is greater then the previous lock period in the locking periods.
+                     "Invalid duration value in unlock periods"
 	* Verify the locking account has necessary balance.
 	* Verify that the fee for this does not exceed the max fee specified.
 	* Verify transaction does not exceed max transaction size.


### PR DESCRIPTION
this PR defines details of the validation of the locking periods. 
performance analysis of large numbers of locking periods has determined a limit of 50 should be used.