### PR TITLE
Update FIP-21 for detailed design iteration 1

### DIFF
--- a/fip-0021.md
+++ b/fip-0021.md
@@ -44,16 +44,17 @@ This FIP proposes an on-chain staking functionality, which rewards users for tak
 
 # Specification
 ## Key concepts
-|Concept|Description|
-|---|---|
-|*Staking Reward Token* (SRT)|Representation of staking rewards. It is attached to an individual account when tokens are staked and also tracked as *Global SRTs*, which represent all SRTs issued.|
-|*Rate of Exchange* (ROE)|Used to determine number of SRTs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|
-|*Tokens Staked*|FIO Tokens staked in an individual account.|
-|*Staked Token Pool*|Sum of all FIO Tokens staked plus *Staking Rewards*.|
-|*Staked Token Pool Minimum*|To avoid ROE volatility, staking should only be allowed, if *Staked Token Pool* counter is greater than 1M FIO Tokens.|
-|*Staking Rewards*|Tokens in treasury earmarked for staking rewards. Comes from 25% of fees collected plus *Staking Rewards Reserves*.|
-|*Staking Rewards Reserves Maximum*|Set to 25,000,000 FIO tokens, it's the maximum number of tokens that can be issued to supplement *Staking Rewards* from fees.|
-|*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|
+|Concept|Description|Scope|
+|---|---|---|
+|*Account Staking Reward Token* (SRT)|Representation of staking rewards. total SRTs for staked tokens will be associated to an individual account when tokens are staked |Account|
+|*Account Tokens Staked*|FIO Tokens staked in an individual account.|Account|
+|*Global Staking Reward Token* (SRT)|Representation of staking rewards. It is tracked as *Global SRTs*, which represent all SRTs issued.|Global|
+|*Staked Token Pool*|Sum of all FIO Tokens staked plus *Global Staking Rewards*.|Global|
+|*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|Global|
+|*Treasury Staking Rewards*|Tokens in treasury earmarked for staking rewards. Comes from 25% of fees collected plus *Staking Rewards Reserves*.|Treasury|
+|*Rate of Exchange* (ROE)|Used to determine number of SRTs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|Computed as needed.|
+|*Staked Token Pool Minimum*|To avoid ROE volatility, staking should only be allowed, if *Staked Token Pool* counter is greater than 1M FIO Tokens.|System Constant|
+|*Staking Rewards Reserves Maximum*|Set to 25,000,000 FIO tokens, it's the maximum number of tokens that can be issued to supplement *Staking Rewards* from fees.|System constant|
 
 ## High-level
 ### Staking
@@ -64,6 +65,14 @@ When tokens are staked, they cannot be transferred, used to pay a FIO Chain fee,
 *Tokens Staked* do count towards voting power of account.
 
 Tokens locked via Mainnet or [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locks, cannot be staked.
+
+If the account has Mainnet locked tokens, then the user may stake and unstake the unlocked portion of those tokens in that account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
+
+If the account has general [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locked tokens, then the user may stake and unstake the unlocked portion of those tokens in the account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
+
+The Account Staking Reward Token, and the Account Tokens Staked are updated when staking occurs. This maintains accurate staking information per account.
+
+
 
 ### Staking Reward Token
 When user stakes FIO Tokens they "exchange" FIO Tokens for *Staking Reward Tokens* (SRTs) at then current *Rate of Exchange* (ROE). SRT is not an actual token and cannot be transferred. It simply acts as a representation of future staking rewards and is attached to the account which is staking.
@@ -92,7 +101,7 @@ In addition, if 25% of fees collected in any one day is less than 25,000 FIO, ne
 The Foundation will burn 25M FIO Tokens from Address Giveaway bucket to ensure total supply stays at 1B.
 
 ### Unstaking
-User can unstake any amount in their account at any point in time. When they do, they will exchange SRTs back into FIO Tokens at then current *Rate of Exchange*. Since the ROE is likely to be higher at time of unstake, they will end up with more FIO Tokens than originally staked.
+User can unstake any amount in their account at any point in time. When they do, they will exchange SRTs back into FIO Tokens at the current *Rate of Exchange*. Since the ROE is likely to be higher at time of unstake, they will end up with more FIO Tokens than originally staked.
 
 Since the user specifies FIO Tokens when unstaking, to determine the amount of SRTs that need to be converted, the following calculation is completed:
 ```
@@ -100,6 +109,8 @@ SRTs to Unstake = SRTs in Account * (Unstaked Tokens/Total Tokens Staked in Acco
 ```
 
 The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again.
+
+The Account Staking Reward Token, and the Account Tokens Staked are updated when unstaking occurs. This maintains accurate staking information per account.
 
 ### Rate of Exchange
 ROE is determined based on the following formula:
@@ -158,8 +169,10 @@ Stake FIO Tokens.
 * Request is validated per Exception handling.
 * stake_fio_tokens fee is collected.
 * RAM of signer is increased.
-* Specified *amount* of FIO Tokens is designated as *Tokens Staked* in the Staker's Account and cannot be spent.
+* *Account Tokens Staked* is incremented by *amount* in account related table.
+* *Account Tokens Staked* cannot be spent by the user.
 * *SRTs to Award* are computed: *amount* / *Rate of Exchange*
+* *Account Staking Reward Token* is incremented by *SRTs to Award* in account related table
 * *Staked Token Pool* count is incremented by *amount*.
 * *Global SRT* count is incremented by *SRTs to Award*.
 #### Exception handling
@@ -285,6 +298,10 @@ Requiring users to vote/proxy within 30 days on ustake was considered, but aband
 An approach was considered to burn the 25% of tokens paid on any fee and then minting that amount when required to pay out the rewards on unstaking. It was abandoned to stay consistent with how fees are collected and tracked today.
 
 # Implementation
+
+## Detailed Design 
+The detailed design, project plan, and implementation plan will be published into the [Development Specification](https://fioprotocol.atlassian.net/wiki/spaces/FD/pages/91127818/FIP-21+FIO+Staking+Development+Spec).
+
 ## Token burning
 Foundation will burn 25,000,000 FIO Tokens from [FIO Address Giveaways](https://kb.fioprotocol.io/fio-token/token-distribution#tokens-minted-over-time) using retire action being implemented in [FIP-22](fip-0022.md). Tokens from the following buckets would be burned:
 ```
@@ -316,7 +333,6 @@ FIO8PTt3EPLuMGjnQvZXUe5TfZJW7DbpWby4VjXFRnxHW5peBsFU1,1000000
 ```
 
 ## Variables to track in state
-* *Rate of Exchange* (ROE)
 * *Staked Token Pool*
 * *Staking Rewards*
 * *Staking Rewards Reserves Minted*

--- a/fip-0021.md
+++ b/fip-0021.md
@@ -5,7 +5,7 @@ status: Draft
 type: Functionality
 author: Pawel Mastalerz <pawel@fioprotocol.io>
 created: 2020-11-18
-updated: 2020-02-16
+updated: 2020-03-09
 ---
 
 # Abstract
@@ -46,10 +46,10 @@ This FIP proposes an on-chain staking functionality, which rewards users for tak
 ## Key concepts
 |Concept|Description|Scope|
 |---|---|---|
-|*Account Staking Reward Token* (SRT)|Representation of staking rewards. total SRTs for staked tokens will be associated to an individual account when tokens are staked |Account|
+|*Account Staking Reward Token* (SRT)|Representation of staking rewards. Total SRTs for staked tokens will be associated to an individual account when tokens are staked |Account|
 |*Account Tokens Staked*|FIO Tokens staked in an individual account.|Account|
 |*Global Staking Reward Token* (SRT)|Representation of staking rewards. It is tracked as *Global SRTs*, which represent all SRTs issued.|Global|
-|*Staked Token Pool*|Sum of all FIO Tokens staked plus *Global Staking Rewards*.|Global|
+|*Staked Token Pool*|Sum of all *Account Tokens Staked* plus *Treasury Staking Rewards*.|Global|
 |*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|Global|
 |*Treasury Staking Rewards*|Tokens in treasury earmarked for staking rewards. Comes from 25% of fees collected plus *Staking Rewards Reserves*.|Treasury|
 |*Rate of Exchange* (ROE)|Used to determine number of SRTs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|Computed as needed.|
@@ -64,15 +64,9 @@ When tokens are staked, they cannot be transferred, used to pay a FIO Chain fee,
 
 *Tokens Staked* do count towards voting power of account.
 
-Tokens locked via Mainnet or [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locks, cannot be staked.
-
-If the account has Mainnet locked tokens, then the user may stake and unstake the unlocked portion of those tokens in that account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
-
-If the account has general [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locked tokens, then the user may stake and unstake the unlocked portion of those tokens in the account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
+Tokens locked via Mainnet or [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locks, cannot be staked. If the account has Mainnet locked tokens, then the user may stake and unstake the unlocked portion of those tokens in that account (all unlocked tokens are eligible for staking, and should stake and unstake as expected). If the account has general [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locked tokens, then the user may stake and unstake the unlocked portion of those tokens in the account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
 
 The Account Staking Reward Token, and the Account Tokens Staked are updated when staking occurs. This maintains accurate staking information per account.
-
-
 
 ### Staking Reward Token
 When user stakes FIO Tokens they "exchange" FIO Tokens for *Staking Reward Tokens* (SRTs) at then current *Rate of Exchange* (ROE). SRT is not an actual token and cannot be transferred. It simply acts as a representation of future staking rewards and is attached to the account which is staking.
@@ -110,7 +104,7 @@ SRTs to Unstake = SRTs in Account * (Unstaked Tokens/Total Tokens Staked in Acco
 
 The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again.
 
-The Account Staking Reward Token, and the Account Tokens Staked are updated when unstaking occurs. This maintains accurate staking information per account.
+The *Account Staking Reward Token*, and the *Account Tokens Staked* are updated when unstaking occurs. This maintains accurate staking information per account.
 
 ### Rate of Exchange
 ROE is determined based on the following formula:
@@ -169,8 +163,7 @@ Stake FIO Tokens.
 * Request is validated per Exception handling.
 * stake_fio_tokens fee is collected.
 * RAM of signer is increased.
-* *Account Tokens Staked* is incremented by *amount* in account related table.
-* *Account Tokens Staked* cannot be spent by the user.
+* *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
 * *SRTs to Award* are computed: *amount* / *Rate of Exchange*
 * *Account Staking Reward Token* is incremented by *SRTs to Award* in account related table
 * *Staked Token Pool* count is incremented by *amount*.


### PR DESCRIPTION
try to clarify some of the design decisions made in the drafting of FIP-21
clarify the scope of various data that is critical to the FIP.
clarify rules for staking and unstaking when there are other locks (Mainnet, and FIP-6).
add link to the detailed design document.