### PR TITLE
Updated FIP-21 based on community feedback

### DIFF
--- a/fip-0021.md
+++ b/fip-0021.md
@@ -5,7 +5,7 @@ status: Draft
 type: Functionality
 author: Pawel Mastalerz <pawel@fioprotocol.io>
 created: 2020-11-18
-updated: 2020-03-09
+updated: 2020-03-18
 ---
 
 # Abstract
@@ -46,19 +46,19 @@ This FIP proposes an on-chain staking functionality, which rewards users for tak
 ## Key concepts
 |Concept|Description|Scope|
 |---|---|---|
-|*Account Staking Reward Token* (SRT)|Representation of staking rewards. Total SRTs for staked tokens will be associated to an individual account when tokens are staked |Account|
+|*Account Staking Reward Point* (SRP)|Representation of staking rewards. Total SRPs for staked tokens will be associated to an individual account when tokens are staked |Account|
 |*Account Tokens Staked*|FIO Tokens staked in an individual account.|Account|
-|*Global Staking Reward Token* (SRT)|Representation of staking rewards. It is tracked as *Global SRTs*, which represent all SRTs issued.|Global|
+|*Global Staking Reward Point* (SRP)|Representation of staking rewards. It is tracked as *Global SRPs*, which represent all SRPs issued.|Global|
 |*Staked Token Pool*|Sum of all *Account Tokens Staked* plus *Treasury Staking Rewards*.|Global|
 |*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|Global|
 |*Treasury Staking Rewards*|Tokens in treasury earmarked for staking rewards. Comes from 25% of fees collected plus *Staking Rewards Reserves*.|Treasury|
-|*Rate of Exchange* (ROE)|Used to determine number of SRTs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|Computed as needed.|
+|*Rate of Exchange* (ROE)|Used to determine number of SRPs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|Computed as needed.|
 |*Staked Token Pool Minimum*|To avoid ROE volatility, staking should only be allowed, if *Staked Token Pool* counter is greater than 1M FIO Tokens.|System Constant|
 |*Staking Rewards Reserves Maximum*|Set to 25,000,000 FIO tokens, it's the maximum number of tokens that can be issued to supplement *Staking Rewards* from fees.|System constant|
 
 ## High-level
 ### Staking
-User can stake any available FIO Token amount in their account at any point in time. To stake, the account has to have voted or proxied tokens within the preceding 30 days. The FIO Tokens do not actually leave the user's account, but are instead "locked" and cannot be spent until unstaked.
+User can stake any available FIO Token amount in their account at any point in time. To stake, the account has to have voted their tokens within the preceding 30 days, or is being proxied or auto-proxied (even if started more than 30 days ago). The FIO Tokens do not actually leave the user's account, but are instead "locked" and cannot be spent until unstaked.
 
 When tokens are staked, they cannot be transferred, used to pay a FIO Chain fee, or [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md).
 
@@ -66,10 +66,10 @@ When tokens are staked, they cannot be transferred, used to pay a FIO Chain fee,
 
 Tokens locked via Mainnet or [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locks, cannot be staked. If the account has Mainnet locked tokens, then the user may stake and unstake the unlocked portion of those tokens in that account (all unlocked tokens are eligible for staking, and should stake and unstake as expected). If the account has general [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) locked tokens, then the user may stake and unstake the unlocked portion of those tokens in the account (all unlocked tokens are eligible for staking, and should stake and unstake as expected).
 
-The Account Staking Reward Token, and the Account Tokens Staked are updated when staking occurs. This maintains accurate staking information per account.
+The Account Staking Reward Point, and the Account Tokens Staked are updated when staking occurs. This maintains accurate staking information per account.
 
-### Staking Reward Token
-When user stakes FIO Tokens they "exchange" FIO Tokens for *Staking Reward Tokens* (SRTs) at then current *Rate of Exchange* (ROE). SRT is not an actual token and cannot be transferred. It simply acts as a representation of future staking rewards and is attached to the account which is staking.
+### Staking Reward Point
+When user stakes FIO Tokens they "exchange" FIO Tokens for *Staking Reward Points* (SRPs) at then current *Rate of Exchange* (ROE). SRP is not an actual token and cannot be transferred. It simply acts as a representation of future staking rewards and is attached to the account which is staking.
 
 ### Staking Rewards
 Currently when a fee is paid, it gets distributed as follows:
@@ -95,21 +95,21 @@ In addition, if 25% of fees collected in any one day is less than 25,000 FIO, ne
 The Foundation will burn 25M FIO Tokens from Address Giveaway bucket to ensure total supply stays at 1B.
 
 ### Unstaking
-User can unstake any amount in their account at any point in time. When they do, they will exchange SRTs back into FIO Tokens at the current *Rate of Exchange*. Since the ROE is likely to be higher at time of unstake, they will end up with more FIO Tokens than originally staked.
+User can unstake any amount in their account at any point in time. When they do, they will exchange SRPs back into FIO Tokens at the current *Rate of Exchange*. Since the ROE is likely to be higher at time of unstake, they will end up with more FIO Tokens than originally staked.
 
-Since the user specifies FIO Tokens when unstaking, to determine the amount of SRTs that need to be converted, the following calculation is completed:
+Since the user specifies FIO Tokens when unstaking, to determine the amount of SRPs that need to be converted, the following calculation is completed:
 ```
-SRTs to Unstake = SRTs in Account * (Unstaked Tokens/Total Tokens Staked in Account)
+SRPs to Unstake = SRPs in Account * (Unstaked Tokens/Total Tokens Staked in Account)
 ```
 
-The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again.
+The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again. All tokens locked as a result of staking should unlock on the same time of day (0:00:01 GMT) to avoid multiple entries into lock table. This way the lock will be anywhere from 6 to 7 days depending on when the unstakle action is called.
 
-The *Account Staking Reward Token*, and the *Account Tokens Staked* are updated when unstaking occurs. This maintains accurate staking information per account.
+The *Account Staking Reward Point*, and the *Account Tokens Staked* are updated when unstaking occurs. This maintains accurate staking information per account.
 
 ### Rate of Exchange
 ROE is determined based on the following formula:
 ```
-ROE = Tokens in Staked Token Pool / Global SRTs
+ROE = Tokens in Staked Token Pool / Global SRPs
 ```
 Tokens in *Staked Token Pool* is:
 * incremented:
@@ -118,13 +118,13 @@ Tokens in *Staked Token Pool* is:
 * decremented:
   * When users unstake tokens
   
-Global SRTs is is:
+Global SRPs is is:
 * incremented:
   * When users stake tokens
 * decremented:
   * When users unstake tokens
   
-Because staking and un-staking increments/decrements tokens in *Staked Token Pool* and *Global SRTs* at the then current ROE, only addition of *Staking Rewards* to *Staked Token Pool* will increase the ROE.
+Because staking and un-staking increments/decrements tokens in *Staked Token Pool* and *Global SRPs* at the then current ROE, only addition of *Staking Rewards* to *Staked Token Pool* will increase the ROE.
 
 In addition:
 * ROE can only go up, so user is guaranteed at least their principal back.
@@ -133,7 +133,7 @@ In addition:
 * Future ROE and therefore annualized return cannot be determined at the time of staking as it is dependent on future fees collected and tokens staked
 
 ### Rewards for TPID
-When user unstakes FIO Tokens, the TPID attached to the unstake action receives 10% of the difference between tokens being unstaked and FIO Tokens received as a result of SRT to FIO Token conversion. If no TPID is provided, the 10% remains undistributed.
+When user unstakes FIO Tokens, the TPID attached to the unstake action receives 10% of the difference between tokens being unstaked and FIO Tokens received as a result of SRP to FIO Token conversion. If no TPID is provided, the 10% remains undistributed.
 
 ## New actions
 ### Stake FIO Tokens
@@ -164,20 +164,21 @@ Stake FIO Tokens.
 * stake_fio_tokens fee is collected.
 * RAM of signer is increased.
 * *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
-* *SRTs to Award* are computed: *amount* / *Rate of Exchange*
-* *Account Staking Reward Token* is incremented by *SRTs to Award* in account related table
+* *SRPs to Award* are computed: *amount* / *Rate of Exchange*
+* *Account Staking Reward Point* is incremented by *SRPs to Award* in account related table
 * *Staked Token Pool* count is incremented by *amount*.
-* *Global SRT* count is incremented by *SRTs to Award*.
+* *Global SRP* count is incremented by *SRPs to Award*.
 #### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|
-|Account not voted or proxied|Staker's account has not voted or proxied in the last 30 days.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Account has not voted or proxied in the last 30 days."|
+|Account not voted or proxied|Staker's account has not voted in the last 30 days and is not proxying.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Account has not voted in the last 30 days and is not proxying."|
 |Invalid amount value|amount format is not valid|400|"amount"|Value sent in, e.g. "-100"|"Invalid amount value"|
 |Invalid fee value|max_fee format is not valid|400|"max_fee"|Value sent in, e.g. "-100"|"Invalid fee value"|
 |Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
 |Insufficient balance|Available (unlocked and unstaked) balance in Staker's account is less than chain fee + *amount*|400|"max_oracle_fee"|Value sent in, e.g. "100000000000"|"Insufficient balance"|
 |Invalid TPID|tpid format is not valid|400|"tpid"|Value sent in, e.g. "notvalidfioaddress"|"TPID must be empty or valid FIO address"|
 |Staking not enabled|*Staked Token Pool* is less than *Staked Token Pool Minimum*.|403|||Type: "Not Avaialble" - this is a nmew type of 403 that would be added.|
+|Signer not actor|Signer not actor|403|||Type: invalid_signature|
 #### Response body
 |Parameter|Format|Definition|
 |---|---|---|
@@ -218,12 +219,12 @@ Unstake FIO Tokens.
 * Request is validated per Exception handling.
 * unstake_fio_tokens fee is collected.
 * RAM of signer is increased.
-* *SRTs to Claim* are computed: *Staker's Account SRTs* * (Unstaked *amount* / *Total Tokens Staked in Staker's Account*)
-* *Staking Reward Amount* is computed: ((*SRTs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.9
-* *TPID Reward Amount* is computed: ((*SRTs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.1
+* *SRPs to Claim* are computed: *Staker's Account SRPs* * (Unstaked *amount* / *Total Tokens Staked in Staker's Account*)
+* *Staking Reward Amount* is computed: ((*SRPs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.9
+* *TPID Reward Amount* is computed: ((*SRPs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.1
 * Unstake *amount* is undesignated as *Tokens Staked* in Staker's Account and can now be spent.
 * *Staking Reward Amount* is transferred to Staker's Account.
-* *SRTs to Claim* are decremented from Staker's Account and from *Global SRT* count.
+* *SRPs to Claim* are decremented from Staker's Account and from *Global SRP* count.
 * *Staked Token Pool* count is decremented by *amount* + *Staking Reward Amount*.
 * If *tpid* was provided, *TPID Reward Amount* is awarded to the *tpid* and decremented from *Staked Token Pool*.
 * *amount* + *Staking Reward Amount* is [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) in Staker's Account for 7 days.
@@ -236,6 +237,7 @@ Unstake FIO Tokens.
 |Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
 |Insufficient balance|Available (unlocked and unstaked) balance in Staker's account is less than chain fee + *amount*|400|"max_oracle_fee"|Value sent in, e.g. "100000000000"|"Insufficient balance"|
 |Invalid TPID|tpid format is not valid|400|"tpid"|Value sent in, e.g. "notvalidfioaddress"|"TPID must be empty or valid FIO address"|
+|Signer not actor|Signer not actor|403|||Type: invalid_signature|
 #### Response body
 |Parameter|Format|Definition|
 |---|---|---|
@@ -278,10 +280,44 @@ No changes
 ##### Example
 No changes
 
+### Get balance
+Modified to consider and include staked tokens.
+#### Modified end point: /get_fio_balance
+#### Request body
+Unchanged
+###### Example
+```
+{
+	"fio_public_key": "FIO8PRe4WRZJj5mkem6qVGKyvNFgPsNnjNN6kPhh6EaCpzCVin5Jj"
+}
+```
+##### Processing
+* Available balance should exclude staked tokens. Staked tokens are returned as new value.
+##### Exception handling
+Unchanged
+##### Response body
+|Parameter|Format|Definition|
+|---|---|---|
+|balance|Int|Total SUF balance associated with supplied public key (includes locked tokens).|
+|available|Int|Available SUF balance associated with supplied public key (does not include locked tokens).|
+|staked|Int|SUFs being staked.|
+|srps|Int|Amount of SRPs in account.|
+|roe|Double|Current SRP-FIO rate of exchange.|
+###### Example
+```
+{
+	"balance": 100000000000,
+	"available": 100000000000,
+ "staked": 1000000000,
+ "srps: 1000000000,
+ "roe": 2.333333333
+}
+```
+
 # Rationale
 ## Other approaches
-There were several versions of staking [discussed and considered](https://fioprotocol.atlassian.net/wiki/spaces/WP/pages/34078744/FIO+Staking). The SRT approach was modeled after [EOSIO REX Implementation](https://github.com/EOSIO/eosio.contracts/issues/117). EOSIO requires a transfer of tokens and issues a transferable REX token. FIO’s implementation does not have to require a transfer because:
-* We do not have a requirement for the reward token to be transferable.
+There were several versions of staking [discussed and considered](https://fioprotocol.atlassian.net/wiki/spaces/WP/pages/34078744/FIO+Staking). The SRP approach was modeled after [EOSIO REX Implementation](https://github.com/EOSIO/eosio.contracts/issues/117). EOSIO requires a transfer of tokens and issues a transferable REX token. FIO’s implementation does not have to require a transfer because:
+* We do not have a requirement for the reward point to be transferable.
 * We do have ability to lock tokens in account.
 
 ## Vote/proxy on unstake
@@ -329,14 +365,14 @@ FIO8PTt3EPLuMGjnQvZXUe5TfZJW7DbpWby4VjXFRnxHW5peBsFU1,1000000
 * *Staked Token Pool*
 * *Staking Rewards*
 * *Staking Rewards Reserves Minted*
-* *Global SRT*
-* *SRTs* per account
+* *Global SRP*
+* *SRPs* per account
 * *Tokens Staked* per account
 * *Daily Staking Rewards*
 * *Total Staking Rewards*
 
 # Backwards Compatibility
-No impact on existing functionality.
+[/get_fio_balance](https://developers.fioprotocol.io/pages/api/fio-api/#post-/get_fio_balance) is the only existing API method being modified, but only a new response elements are added, so wallets currently implementing this call should not be affected.
 
 # Future considerations
 None

--- a/fip-0021.md
+++ b/fip-0021.md
@@ -35,7 +35,8 @@ This FIP proposes **FIO Staking**, an on-chain program which rewards users for p
 |Contract|Action|Endpoint|Description|
 |---|---|---|---|
 |Multiple|Fee collection on any action|Multiple|Modified to redirect 25% of fee paid to Staking Rewards.|
-|fio.treasury|bpclaim|claim_bp_rewards|Modfied to mint Staking Reward Reserves.|
+|fio.treasury|bpclaim|claim_bp_rewards|Modified to mint Staking Reward Reserves.|
+|||get_fio_balance|Modified to consider and include staked tokens.|
 
 # Motivation
 The FIO Protocol is subject to the network effect, meaning the more participants adopt it, the more useful it is to all. To accelerate the adoption, on-chain incentives for integrators in the form of TPID rewards and New User Bounties, as well as for block producers in the form of rewards and reserves are built into the FIO Chain. Currently, there are no incentives for end-users. Yet early token holders add value to the network by voting for block producers and helping the network grow.
@@ -102,7 +103,7 @@ Since the user specifies FIO Tokens when unstaking, to determine the amount of S
 SRPs to Unstake = SRPs in Account * (Unstaked Tokens/Total Tokens Staked in Account)
 ```
 
-The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again. All tokens locked as a result of staking should unlock on the same time of day (0:00:01 GMT) to avoid multiple entries into lock table. This way the lock will be anywhere from 6 to 7 days depending on when the unstakle action is called.
+The unstaked amount of FIO Tokens is locked in the account for a period of 7 days (using [FIP-6](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) logic) before it can be transferred or staked again. All tokens locked as a result of staking should unlock on the same time of day (0:00:01 GMT) to avoid multiple entries into lock table. This way the lock will be anywhere from 6 to 7 days depending on when the unstake action is called.
 
 The *Account Staking Reward Point*, and the *Account Tokens Staked* are updated when unstaking occurs. This maintains accurate staking information per account.
 
@@ -372,7 +373,7 @@ FIO8PTt3EPLuMGjnQvZXUe5TfZJW7DbpWby4VjXFRnxHW5peBsFU1,1000000
 * *Total Staking Rewards*
 
 # Backwards Compatibility
-[/get_fio_balance](https://developers.fioprotocol.io/pages/api/fio-api/#post-/get_fio_balance) is the only existing API method being modified, but only a new response elements are added, so wallets currently implementing this call should not be affected.
+[/get_fio_balance](https://developers.fioprotocol.io/pages/api/fio-api/#post-/get_fio_balance) is the only existing API method being modified, but only new response elements are added, so wallets currently implementing this call should not be affected.
 
 # Future considerations
 None


### PR DESCRIPTION
* Changed Staking Reward Token (SRT) to Staking Reward Point (SRP)
* Removed 30-day requirement if proxying and explicitly allowed auto-proxy as staking condition
* Added "Signer not actor" 403 error
* Added logic to unlock staked tokens at same time of day to avoid multiple entries into lock table
* Modified get_fio_balance getter