### PR TITLE
Renamed *Staked Token Pool*

### DIFF
--- a/fip-0021.md
+++ b/fip-0021.md
@@ -50,11 +50,12 @@ This FIP proposes an on-chain staking functionality, which rewards users for tak
 |*Account Staking Reward Point* (SRP)|Representation of staking rewards. Total SRPs for staked tokens will be associated to an individual account when tokens are staked |Account|
 |*Account Tokens Staked*|FIO Tokens staked in an individual account.|Account|
 |*Global Staking Reward Point* (SRP)|Representation of staking rewards. It is tracked as *Global SRPs*, which represent all SRPs issued.|Global|
-|*Staked Token Pool*|Sum of all *Account Tokens Staked* plus *Treasury Staking Rewards*.|Global|
-|*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|Global|
+|*Staked Token Pool*|Sum of all *Account Tokens Staked*.|Global|
 |*Treasury Staking Rewards*|Tokens in treasury earmarked for staking rewards. Comes from 25% of fees collected plus *Staking Rewards Reserves*.|Treasury|
+|*Combined Token Pool*|*Staked Token Pool* + *Treasury Staking Rewards*.|Global|
+|*Staking Rewards Reserves Minted*|Amount of Staking Rewards Reserves minted to date.|Global|
 |*Rate of Exchange* (ROE)|Used to determine number of SRPs to issue based on staking amount, or additional FIO Tokens to issue when unstaking.|Computed as needed.|
-|*Staked Token Pool Minimum*|To avoid ROE volatility, Staking Rewards will only be credited if *Staked Token Pool* counter is greater than 1M FIO Tokens.|System Constant|
+|*Combined Token Pool Minimum*|To avoid ROE volatility, Staking Rewards will only be credited if *Combined Token Pool* counter is greater than 1M FIO Tokens.|System Constant|
 |*Staking Rewards Reserves Maximum*|Set to 25,000,000 FIO tokens, it's the maximum number of tokens that can be issued to supplement *Staking Rewards* from fees.|System constant|
 
 ## High-level
@@ -95,8 +96,8 @@ In addition, if 25% of fees collected in any one day is less than 25,000 FIO, ne
 
 The Foundation will burn 25M FIO Tokens from Address Giveaway bucket to ensure total supply stays at 1B.
 
-#### Staked Token Pool Minimum
-Staking Rewards will only accrue if *Staked Token Pool* is equal to or greater than *Staked Token Pool Minimum*, which will be set to 1M. This is to prevent big swings in ROE when Staking Rewards are deposited when *Staked Token Pool* is low.
+#### Combined Token Pool Minimum
+Staking Rewards will only accrue if *Combined Token Pool* is equal to or greater than *Combined Token Pool Minimum*, which will be set to 1M. This is to prevent big swings in ROE when Staking Rewards are deposited when *Combined Token Pool* is low.
 
 ### Unstaking
 User can unstake any amount in their account at any point in time. When they do, they will exchange SRPs back into FIO Tokens at the current *Rate of Exchange*. Since the ROE is likely to be higher at time of unstake, they will end up with more FIO Tokens than originally staked.
@@ -113,9 +114,9 @@ The *Account Staking Reward Point*, and the *Account Tokens Staked* are updated 
 ### Rate of Exchange
 ROE is determined based on the following formula:
 ```
-ROE = Tokens in Staked Token Pool / Global SRPs
+1 SRP = [ Tokens in Combined Token Pool / Global SRPs ] FIO
 ```
-Tokens in *Staked Token Pool* is:
+Tokens in *Combined Token Pool* is:
 * incremented:
   * When users stake tokens
   * When tokens are earmarked as *Staking Rewards*
@@ -128,9 +129,9 @@ Global SRPs is is:
 * decremented:
   * When users unstake tokens
   
-Because staking and un-staking increments/decrements tokens in *Staked Token Pool* and *Global SRPs* at the then current ROE, only addition of *Staking Rewards* to *Staked Token Pool* will increase the ROE.
+Because staking and un-staking increments/decrements tokens in *Combined Token Pool* and *Global SRPs* at the then current ROE, only addition of *Staking Rewards* to *Combined Token Pool* will increase the ROE.
 
-ROE will be initialize at 1 FIO = 1 SRT and remain that until *Staked Token Pool* is equal to or greater than *Staked Token Pool Minimum*.
+ROE will be initialize at 1 FIO = 1 SRT and remain that until *Combined Token Pool* is equal to or greater than *Combined Token Pool Minimum*.
 
 In addition:
 * ROE can only go up, so user is guaranteed at least their principal back.
@@ -172,7 +173,7 @@ Stake FIO Tokens.
 * *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
 * *SRPs to Award* are computed: *amount* / *Rate of Exchange*
 * *Account Staking Reward Point* is incremented by *SRPs to Award* in account related table
-* *Staked Token Pool* count is incremented by *amount*.
+* *Combined Token Pool* count is incremented by *amount*.
 * *Global SRP* count is incremented by *SRPs to Award*.
 * check for maximum FIO transaction size is applied
 #### Exception handling
@@ -184,7 +185,6 @@ Stake FIO Tokens.
 |Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
 |Insufficient balance|Available (unlocked and unstaked) balance in Staker's account is less than chain fee + *amount*|400|"max_oracle_fee"|Value sent in, e.g. "100000000000"|"Insufficient balance"|
 |Invalid TPID|tpid format is not valid|400|"tpid"|Value sent in, e.g. "notvalidfioaddress"|"TPID must be empty or valid FIO address"|
-|Staking not enabled|*Staked Token Pool* is less than *Staked Token Pool Minimum*.|403|||Type: "Not Avaialble" - this is a nmew type of 403 that would be added.|
 |Signer not actor|Signer not actor|403|||Type: invalid_signature|
 #### Response body
 |Parameter|Format|Definition|
@@ -232,8 +232,8 @@ Unstake FIO Tokens.
 * Unstake *amount* is undesignated as *Tokens Staked* in Staker's Account and can now be spent.
 * *Staking Reward Amount* is transferred to Staker's Account.
 * *SRPs to Claim* are decremented from Staker's Account and from *Global SRP* count.
-* *Staked Token Pool* count is decremented by *amount* + *Staking Reward Amount*.
-* If *tpid* was provided, *TPID Reward Amount* is awarded to the *tpid* and decremented from *Staked Token Pool*.
+* *Combined Token Pool* count is decremented by *amount* + *Staking Reward Amount*.
+* If *tpid* was provided, *TPID Reward Amount* is awarded to the *tpid* and decremented from *Combined Token Pool*.
 * check for max FIO transaction size exceeded will be applied.
 * *amount* + *Staking Reward Amount* is [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) in Staker's Account for 7 days.
 #### Exception handling
@@ -279,7 +279,7 @@ When bpclaim is ran for the first time in a 24-hour period and payment schedule 
   * *Daily Staking Rewards* is incremented by the tokens minted.
 * *Daily Staking Rewards* amount is:
   * Added to *Total Staking Rewards*
-  * Added to *Staked Token Pool*, which modifies ROE
+  * Added to *Combined Token Pool*, which modifies ROE
   * Set to 0
 #### Exception handling
 No changes
@@ -370,6 +370,7 @@ FIO8PTt3EPLuMGjnQvZXUe5TfZJW7DbpWby4VjXFRnxHW5peBsFU1,1000000
 ```
 
 ## Variables to track in state
+* *Combined Token Pool*
 * *Staked Token Pool*
 * *Staking Rewards*
 * *Staking Rewards Reserves Minted*


### PR DESCRIPTION
*Staked Token Pool* now includes only tokens staked, while *Combined Token Pool* includes *Staked Token Pool* + *Treasury Staking Rewards*