### PR TITLE
FIP-21 mods for new contract and system account. fio.staking

### DIFF
--- a/fip-0021.md
+++ b/fip-0021.md
@@ -25,11 +25,16 @@ This FIP proposes **FIO Staking**, an on-chain program which rewards users for p
 
 **Total token supply increase/(decrease): 0**
 
+## New Contracts
+A new system account will be added to the FIO protocol. This will be called fio.staking. This new account will have a new contract of the same name. This contract will contain the global state and account wise information required for staking. The contract will also contain the required actions to modify this state information. The goal of this new contract is to reduce the contract bloat that might result if we were to add this information directly to the fio.system contract.  
+
+
 ## New actions
 |Contract|Action|Endpoint|Description|
 |---|---|---|---|
-|fio.system|stakefio|stake_fio_tokens|Stake FIO Tokens.|
-|fio.system|unstakefio|unstake_fio_tokens|Unstake FIO Tokens.|
+|fio.staking|stakefio|stake_fio_tokens|Stake FIO Tokens.|
+|fio.staking|unstakefio|unstake_fio_tokens|Unstake FIO Tokens.|
+
 
 ## Modified actions
 |Contract|Action|Endpoint|Description|
@@ -145,7 +150,7 @@ When user unstakes FIO Tokens, the TPID attached to the unstake action receives 
 ## New actions
 ### Stake FIO Tokens
 Stake FIO Tokens.
-#### Contract: fio.system
+#### Contract: fio.staking
 #### New action: *stakefio*
 #### New end point: /stake_fio_tokens
 #### New fee: stake_fio_tokens, bundle-eligible (1 bundled transaction) fee amount will be determined during development and updated here
@@ -170,12 +175,14 @@ Stake FIO Tokens.
 * Request is validated per Exception handling.
 * stake_fio_tokens fee is collected.
 * RAM of signer is increased. amount of RAM increase will be computed during development and updated in this FIP
-* *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
 * *SRPs to Award* are computed: *amount* / *Rate of Exchange*
+* *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
 * *Account Staking Reward Point* is incremented by *SRPs to Award* in account related table
 * *Combined Token Pool* count is incremented by *amount*.
-* *Global SRP* count is incremented by *SRPs to Award*.
+* *Global SRP count* is incremented by *SRPs to Award*.
+* *Staked Token Pool* is incremented by *amount*.
 * check for maximum FIO transaction size is applied
+
 #### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|
@@ -201,7 +208,7 @@ Stake FIO Tokens.
 
 ### Unstake FIO Tokens
 Unstake FIO Tokens.
-#### Contract: fio.system
+#### Contract: fio.staking
 #### New action: *unstakefio*
 #### New end point: /unstake_fio_tokens
 #### New fee: unstake_fio_tokens, bundle-eligible (1 bundled transaction) fee amount will be computed during development and updated here.
@@ -226,17 +233,19 @@ Unstake FIO Tokens.
 * Request is validated per Exception handling.
 * unstake_fio_tokens fee is collected.
 * RAM of signer is increased, amount of ram increment will be computed and updated into FIP during development
-* *SRPs to Claim* are computed: *Staker's Account SRPs* * (Unstaked *amount* / *Total Tokens Staked in Staker's Account*)
+* *SRPs to Claim* are computed: *Staker's Account SRPs* * (Unstaked *amount* / * Total Tokens Staked in Staker's Account*)
 * *Staking Reward Amount* is computed: ((*SRPs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.9
 * *TPID Reward Amount* is computed: ((*SRPs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.1
-* Unstake *amount* is undesignated as *Tokens Staked* in Staker's Account and can now be spent.
-* *Staking Reward Amount* is transferred to Staker's Account.
-	* Memo: "Paying Staking Rewards"
-* *SRPs to Claim* are decremented from Staker's Account and from *Global SRP* count.
+* *Account Tokens Staked* is decremented by amount in account related table.
+* *Account Staking Reward Point* is decremented by *SRPs to Award* in account related table
+* *Staking Reward Amount* is transferred to Staker's Account. Memo: "Paying Staking Rewards"
+* *Global SRP count* is decremented by *SRPs to Claim* .
 * *Combined Token Pool* count is decremented by *amount* + *Staking Reward Amount*.
-* If *tpid* was provided, *TPID Reward Amount* is awarded to the *tpid* and decremented from *Combined Token Pool*.
+* *Staked Token Pool* is decremented by *amount*
+* If tpid was provided, *TPID Reward Amount* is awarded to the tpid and decremented from *Combined Token Pool*.
 * check for max FIO transaction size exceeded will be applied.
-* *amount* + *Staking Reward Amount* is [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) in Staker's Account for 7 days.
+* *amount* + *Staking Reward Amount* is [locked]is [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) in Staker's Account for 7 days. in Staker's Account for 7 days.
+
 #### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|


### PR DESCRIPTION
update FIP-21 to reflect the decision to place staking into its own contract/account, funds will still be kept in treasury. but tables and actions will be placed into fio.staking contract, then this contract will be integrated into fio.system, fio.token, and fio.treasury.