### PR TITLE
Updates from ed

### DIFF
--- a/fip-0021.md
+++ b/fip-0021.md
@@ -5,7 +5,7 @@ status: Accepted
 type: Functionality
 author: Pawel Mastalerz <pawel@fioprotocol.io>
 created: 2020-11-18
-updated: 2020-04-13
+updated: 2020-04-30
 ---
 
 # Abstract
@@ -28,13 +28,11 @@ This FIP proposes **FIO Staking**, an on-chain program which rewards users for p
 ## New Contracts
 A new system account will be added to the FIO protocol. This will be called fio.staking. This new account will have a new contract of the same name. This contract will contain the global state and account wise information required for staking. The contract will also contain the required actions to modify this state information. The goal of this new contract is to reduce the contract bloat that might result if we were to add this information directly to the fio.system contract.  
 
-
 ## New actions
 |Contract|Action|Endpoint|Description|
 |---|---|---|---|
 |fio.staking|stakefio|stake_fio_tokens|Stake FIO Tokens.|
 |fio.staking|unstakefio|unstake_fio_tokens|Unstake FIO Tokens.|
-
 
 ## Modified actions
 |Contract|Action|Endpoint|Description|
@@ -65,7 +63,7 @@ This FIP proposes an on-chain staking functionality, which rewards users for tak
 
 ## High-level
 ### Staking
-User can stake any available FIO Token amount in their account at any point in time. To stake, the account has to have voted their tokens within the preceding 30 days, or is being proxied or auto-proxied (even if started more than 30 days ago). The FIO Tokens do not actually leave the user's account, but are instead "locked" and cannot be spent until unstaked.
+User can stake any available FIO Token amount in their account at any point in time. To stake, the account has to be voting for at least 1 BP or proxying/auto-proxying. The FIO Tokens do not actually leave the user's account, but are instead "locked" and cannot be spent until unstaked.
 
 When tokens are staked, they cannot be transferred, used to pay a FIO Chain fee, or [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md).
 
@@ -145,7 +143,7 @@ In addition:
 * Future ROE and therefore annualized return cannot be determined at the time of staking as it is dependent on future fees collected and tokens staked
 
 ### Rewards for TPID
-When user unstakes FIO Tokens, the TPID attached to the unstake action receives 10% of the difference between tokens being unstaked and FIO Tokens received as a result of SRP to FIO Token conversion. If no TPID is provided, the 10% remains undistributed.
+When user unstakes FIO Tokens, the TPID attached to the unstake action receives (using same methodology as all TPID rewards: accrues to TPID and is claimed using claim_tpid_rewards) 10% of the difference between tokens being unstaked and FIO Tokens received as a result of SRP to FIO Token conversion. If no TPID is provided, the 10% remains undistributed.
 
 ## New actions
 ### Stake FIO Tokens
@@ -159,6 +157,7 @@ Stake FIO Tokens.
 |Parameter|Required|Format|Definition|
 |---|---|---|---|
 |amount|Yes|Int|Amount of SUFs to stake.|
+|fio_address|Yes|String|FIO Address if using bundled transactions to pay. May be left empty if paying a fee instead.|
 |max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
 |tpid|Yes|FIO Address|FIO Address of the entity which generates this transaction. TPID rewards will be paid to this address. Set to empty if not known.|
 |actor|Yes|12 character string|Valid actor of signer|
@@ -166,6 +165,7 @@ Stake FIO Tokens.
 ```
 {
   "amount": 1000000000,
+  "fio_address": alice@purse,
   "max_fee": 1000000000,
   "tpid": "rewards@wallet",
   "actor": "aftyershcu22"
@@ -173,7 +173,7 @@ Stake FIO Tokens.
 ```
 #### Processing
 * Request is validated per Exception handling.
-* stake_fio_tokens fee is collected.
+* stake_fio_tokens fee is collected or bundled transaction deducted (if FIO Address passed in and has available bundled transactions)
 * RAM of signer is increased. amount of RAM increase will be computed during development and updated in this FIP
 * *SRPs to Award* are computed: *amount* / *Rate of Exchange*
 * *Account Tokens Staked* is incremented by *amount* in account related table. *Account Tokens Staked* cannot be spent by the user.
@@ -186,12 +186,16 @@ Stake FIO Tokens.
 #### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|
-|Account not voted or proxied|Staker's account has not voted in the last 30 days and is not proxying.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Account has not voted in the last 30 days and is not proxying."|
+|Account not voted or proxied|Staker's account has not voted for at least 1 BP or is not proxying/auto-proxying.|400|"actor"|Value sent in, e.g. "aftyershcu22"|"Account has not voted or is not proxying."|
 |Invalid amount value|amount format is not valid|400|"amount"|Value sent in, e.g. "-100"|"Invalid amount value"|
+|Invalid FIO Address|Format of FIO Address not valid, FIO Address does not exist or is not mapped to a valid FIO Public Key.|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Address invalid, does not exist."|
+|FIO Address expired|Supplied FIO Address has expired|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Address expired."|
+|FIO Domain expired|Domain of supplied FIO Address has expired more than 30 days ago|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Domain expired."|
 |Invalid fee value|max_fee format is not valid|400|"max_fee"|Value sent in, e.g. "-100"|"Invalid fee value"|
 |Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
 |Insufficient balance|Available (unlocked and unstaked) balance in Staker's account is less than chain fee + *amount*|400|"max_fee"|Value sent in, e.g. "100000000000"|"Insufficient balance"|
 |Invalid TPID|tpid format is not valid|400|"tpid"|Value sent in, e.g. "notvalidfioaddress"|"TPID must be empty or valid FIO address"|
+|Not owner of FIO Address|The signer does not own the FIO Address|403|||Type: invalid_signature|
 |Signer not actor|Signer not actor|403|||Type: invalid_signature|
 #### Response body
 |Parameter|Format|Definition|
@@ -217,6 +221,7 @@ Unstake FIO Tokens.
 |Parameter|Required|Format|Definition|
 |---|---|---|---|
 |amount|Yes|Int|Amount of SUFs to unstake.|
+|fio_address|Yes|String|FIO Address if using bundled transactions to pay. May be left empty if paying a fee instead.|
 |max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
 |tpid|Yes|FIO Address|FIO Address of the entity which generates this transaction. TPID rewards will be paid to this address. Set to empty if not known.|
 |actor|Yes|12 character string|Valid actor of signer|
@@ -224,6 +229,7 @@ Unstake FIO Tokens.
 ```
 {
   "amount": 1000000000,
+  "fio_address": alice@purse,
   "max_fee": 1000000000,
   "tpid": "rewards@wallet",
   "actor": "aftyershcu22"
@@ -231,7 +237,7 @@ Unstake FIO Tokens.
 ```
 #### Processing
 * Request is validated per Exception handling.
-* unstake_fio_tokens fee is collected.
+* unstake_fio_tokens fee is collected or bundled transaction deducted (if FIO Address passed in and has available bundled transactions)
 * RAM of signer is increased, amount of ram increment will be computed and updated into FIP during development
 * *SRPs to Claim* are computed: *Staker's Account SRPs* * (Unstaked *amount* / * Total Tokens Staked in Staker's Account*)
 * *Staking Reward Amount* is computed: ((*SRPs to Claim* * *Rate of Exchnage*) - Unstake *amount*) * 0.9
@@ -242,7 +248,7 @@ Unstake FIO Tokens.
 * *Global SRP count* is decremented by *SRPs to Claim* .
 * *Combined Token Pool* count is decremented by *amount* + *Staking Reward Amount*.
 * *Staked Token Pool* is decremented by *amount*
-* If tpid was provided, *TPID Reward Amount* is awarded to the tpid and decremented from *Combined Token Pool*.
+* If tpid was provided, *TPID Reward Amount* is awarded (using same methodology as all TPID rewards: accrues to TPID and is claimed using claim_tpid_rewards) to the tpid and decremented from *Combined Token Pool*.
 * check for max FIO transaction size exceeded will be applied.
 * *amount* + *Staking Reward Amount* is [locked]is [locked](https://github.com/fioprotocol/fips/blob/master/fip-0006.md) in Staker's Account for 7 days. in Staker's Account for 7 days.
 
@@ -252,9 +258,13 @@ Unstake FIO Tokens.
 |Invalid amount value|amount format is not valid|400|"amount"|Value sent in, e.g. "-100"|"Invalid amount value"|
 |Ustake exceeds staked|amount to unstake is greater than the total staked by account|400|"amount"|Value sent in, e.g. "100000000000"|"Cannot unstake more than staked."|
 |Invalid fee value|max_fee format is not valid|400|"max_fee"|Value sent in, e.g. "-100"|"Invalid fee value"|
+|Invalid FIO Address|Format of FIO Address not valid, FIO Address does not exist or is not mapped to a valid FIO Public Key.|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Address invalid, does not exist."|
+|FIO Address expired|Supplied FIO Address has expired|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Address expired."|
+|FIO Domain expired|Domain of supplied FIO Address has expired more than 30 days ago|400|"fio_address"|Value sent in, i.e. "purse@alice"|"FIO Domain expired."|
 |Fee exceeds maximum|Actual fee is greater than supplied max_fee|400|"max_fee"|Value sent in, e.g. "1000000000"|"Fee exceeds supplied maximum"|
 |Insufficient balance|Available (unlocked and unstaked) balance in Staker's account is less than chain fee + *amount*|400|"max_oracle_fee"|Value sent in, e.g. "100000000000"|"Insufficient balance"|
 |Invalid TPID|tpid format is not valid|400|"tpid"|Value sent in, e.g. "notvalidfioaddress"|"TPID must be empty or valid FIO address"|
+|Not owner of FIO Address|The signer does not own the FIO Address|403|||Type: invalid_signature|
 |Signer not actor|Signer not actor|403|||Type: invalid_signature|
 #### Response body
 |Parameter|Format|Definition|
@@ -396,4 +406,3 @@ None
 
 # Discussion link
 https://fioprotocol.atlassian.net/wiki/spaces/WP/pages/34078744/FIO+Staking
-

--- a/fip-0021.md
+++ b/fip-0021.md
@@ -5,7 +5,7 @@ status: Accepted
 type: Functionality
 author: Pawel Mastalerz <pawel@fioprotocol.io>
 created: 2020-11-18
-updated: 2020-04-30
+updated: 2021-04-30
 ---
 
 # Abstract


### PR DESCRIPTION
* Removed requirement to have voted in lats 30 days - now good if voting for at least 1 BP or proxying/auto-proxying.
* Added FIO Address to stake and ustake as it's needed to deduct bundled transaction, duh!
* Clarified that TPID staking reward is not paid immediately, but follows same process as all other TPID rewards.