### PR TITLE
Increase RAM for FIP-11 action call due to post migration changes.

### DIFF
--- a/fip-0011.md
+++ b/fip-0011.md
@@ -32,7 +32,7 @@ There are a couple of improvements which can further enhanced the usability:
 Transfers FIO tokens and records OBT Data.
 #### New action: trnsfiopubad
 #### New end point: /transfer_tokens_fio_add
-#### RAM increase: 2,560 bytes
+#### RAM increase: 4,098 bytes
 #### New fee: transfer_tokens_fio_add: 3000000000, bundle-eligible (uses 5 bundled transaction)
 #### Request
 |Parameter|Required|Format|Definition|


### PR DESCRIPTION
RAM increases for recordobt were increased to allow for more lookup logic possibilities post-migration. This increase should also be adapted to FIP-11b to align with the added functionality. 