### PR TITLE
FIP27 updates

### DIFF
--- a/fip-0027.md
+++ b/fip-0027.md
@@ -63,8 +63,8 @@ Maps a specific NFT to a FIO Address.
 |nfts|hash|Yes|String|SHA-256 hash of NFT asset, e.g. media url. May be left blank if not applicable. Max 64 characters.|
 |nfts|metadata|Yes|String|Serialized json, max. 64 chars. May be left empty.|
 ||max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
-||tpid|Yes|FIO Address|FIO Address of the entity which generates this transaction. TPID rewards will be paid to this address. Set to empty if not known.|
 ||actor|Yes|12 character string|Valid actor of signer|
+||tpid|Yes|FIO Address|FIO Address of the entity which generates this transaction. TPID rewards will be paid to this address. Set to empty if not known.|
 ##### Example
 ```
 {
@@ -88,8 +88,8 @@ Maps a specific NFT to a FIO Address.
     }
   ],
   "max_fee": 0,
-  "tpid": "rewards@wallet",
-  "actor": "aftyershcu22"
+  "actor": "aftyershcu22",
+  "tpid": "rewards@wallet"
 }
 ```
 #### Metadata format
@@ -153,8 +153,8 @@ Removes NFT from FIO Address
 |nfts|contract_address|Yes|String|Min chars: 1, Max chars: 128|
 |nfts|token_id|Yes|String|Token ID of NFT. May be left blank if not applicable. Max 64 characters.|
 ||max_fee|Yes|max fee SUFs|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by /get_fee for correct value.|
-||tpid|Yes|FIO Address of TPID, See FIO Address validation rules|FIO Address of the wallet which generates this transaction. This FIO Address will be paid 10% of the fee. See FIO Protocol#TPIDs for details. Set to empty if not known.|
 ||actor|Yes|FIO account name|FIO account for the signer, the account owning this payee FIO Address.|
+||tpid|Yes|FIO Address of TPID, See FIO Address validation rules|FIO Address of the wallet which generates this transaction. This FIO Address will be paid 10% of the fee. See FIO Protocol#TPIDs for details. Set to empty if not known.|
 ###### Example
 ```
 {
@@ -171,8 +171,8 @@ Removes NFT from FIO Address
       "token_id": "2199023271139"
     }],
   "max_fee": 0,
-  "tpid": "rewards@wallet",
-  "actor": "aftyershcu22"
+  "actor": "aftyershcu22",
+  "tpid": "rewards@wallet"
 }
 ```
 #### Processing
@@ -221,15 +221,15 @@ Removes all NFTs from FIO Address by adding to burn queue.
 |---|---|---|---|
 |fio_address|Yes|fio address, see FIO address validation rules.|FIO Address which will have NFT removed.|
 |max_fee|Yes|max fee SUFs|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by /get_fee for correct value.|
-|tpid|Yes|FIO Address of TPID, See FIO Address validation rules|FIO Address of the wallet which generates this transaction. This FIO Address will be paid 10% of the fee. See FIO Protocol#TPIDs for details. Set to empty if not known.|
 |actor|Yes|FIO account name|FIO account for the signer, the account owning this payee FIO Address.|
+|tpid|Yes|FIO Address of TPID, See FIO Address validation rules|FIO Address of the wallet which generates this transaction. This FIO Address will be paid 10% of the fee. See FIO Protocol#TPIDs for details. Set to empty if not known.|
 ###### Example
 ```
 {
   "fio_address": "purse@alice",
   "max_fee": 0,
-  "tpid": "rewards@wallet",
-  "actor": "aftyershcu22"
+  "actor": "aftyershcu22",
+  "tpid": "rewards@wallet"
 }
 ```
 #### Processing

--- a/fip-0027.md
+++ b/fip-0027.md
@@ -61,7 +61,7 @@ Maps a specific NFT to a FIO Address.
 |nfts|token_id|Yes|String|Token ID of NFT. May be left blank if not applicable. Max 64 characters.|
 |nfts|url|Yes|String|URL of NFT asset, e.g. media url. May be left blank if not applicable. Max 128 characters.|
 |nfts|hash|Yes|String|SHA-256 hash of NFT asset, e.g. media url. May be left blank if not applicable. Max 64 characters.|
-|nfts|metdata|Yes|String|Serialized json, max. 64 chars. May be left empty.|
+|nfts|metadata|Yes|String|Serialized json, max. 64 chars. May be left empty.|
 ||max_fee|Yes|Positive Int|Maximum amount of SUFs the user is willing to pay for fee. Should be preceded by [/get_fee](https://developers.fioprotocol.io/api/api-spec/reference/get-fee/get-fee) for correct value.|
 ||tpid|Yes|FIO Address|FIO Address of the entity which generates this transaction. TPID rewards will be paid to this address. Set to empty if not known.|
 ||actor|Yes|12 character string|Valid actor of signer|


### PR DESCRIPTION
The actual implementation of the FIP27 setters reversed the tpid and actor fields. In fio-go, the ordering is important to ensure that when binary marshalling is performed that the correct order and types are used. This PR reconciles the FIP with the actual implementation, which reversed the actor and tpid parameters.