### PR TITLE
FIP-27 Updates

### DIFF
--- a/fip-0027.md
+++ b/fip-0027.md
@@ -429,7 +429,7 @@ Returns all mapped NFTs which have the specified contract address and token id.
 ```
 #### Processing
 * Request is validated per Exception handling
-* NFTs which match the chain_code, contract_address, token_id combination are returned. Omitting or providing empty token_id will not return NFTs which have the same chain_code, contract_address, but non-empty token_id. In other words, empty token_id is not a wildcard.
+* NFTs which match the chain_code, contract_address, token_id combination are returned. Omitting or providing empty token_id will return NFTs which have the same chain_code, contract_address. In other words, empty token_id field is a wildcard.
 #### Exception handling
 |Error condition|Trigger|Type|fields:name|fields:value|Error message|
 |---|---|---|---|---|---|


### PR DESCRIPTION
get_nfts_contract endpoint spec changed to allow empty token_id field as a wildcard (returns all results for a contract address on the same chain code)