### PR TITLE
New FIP-35: Increase max size of token_id in addnft

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ FIPs describe proposed changes to the FIO Protocol.
 |[FIP-32](fip-0032.md)|Allow unlimited size of content parameter in New Funds Request|Accepted|
 |[FIP-33](fip-0033.md)|Allow $ in token codes|Accepted|
 |[FIP-34](fip-0034.md)|Allow unlimited size of content parameter in Record OBT Data|Accepted|
+|[FIP-35](fip-0035.md)|Increase max size of token_id in addnft|Accepted|
 
 ## Contributing
 ### Review FIPs

--- a/fip-0035.md
+++ b/fip-0035.md
@@ -1,0 +1,45 @@
+---
+fip: 35
+title: Increase max size of token_id in addnft
+status: Accepted
+type: Functionality
+author: Pawel Mastalerz <pawel@fioprotocol.io>
+created: 2021-12-13
+updated: 2021-12-13
+---
+
+# Abstract
+This FIP modifies onchain validation to allow token_id in addnft action to be max 128 characters, up from 64.
+
+## Modified actions
+|Contract|Action|Endpoint|Description|
+|---|---|---|---|
+|fio.address|addnft|/add_nft|Modifies onchain validation to allow token_id to be max 128 characters, up from 64.|
+
+# Motivation
+It appears that some Ethereum NFT contracts use token ids that are longer than 64 characters, current max.
+
+# Specification
+## Modified actions
+### Map blockchain public address
+Modifies onchain validation to allow token_id to be max 128 characters, up from 64.
+#### Contract: fio.address
+#### Action: addnft
+#### Request body
+No change
+#### Processing
+* Modifies onchain validation to allow token_id to be max 128 characters, up from 64.
+#### Response body
+No change
+
+# Rationale
+Increasing max size is the easiest implementation.
+
+# Backwards Compatibility
+No backwards compatibility issues.
+
+# Future considerations
+None
+  
+# Discussion link
+https://fioprotocol.atlassian.net/browse/WP-885


### PR DESCRIPTION
Going straight to Accepted, due to simplicity of the FIP.