### PR TITLE
Remove actor param from unregoracle

### DIFF
--- a/fip-0017a.md
+++ b/fip-0017a.md
@@ -235,8 +235,7 @@ Unregister Oracle.
 ##### Example
 ```
 {
-  "oracle_actor": "aftyershcu21",
-  "actor": "eosio"
+  "oracle_actor": "aftyershcu21"
 }
 ```
 #### Processing

--- a/fip-0017a.md
+++ b/fip-0017a.md
@@ -232,7 +232,6 @@ Unregister Oracle.
 |Parameter|Required|Format|Definition|
 |---|---|---|---|
 |oracle_actor|Yes|12 character string|Valid actor (account) of oracle.|
-|actor|Yes|12 character string|Valid actor of signer|
 ##### Example
 ```
 {


### PR DESCRIPTION
Since this param is not used during the validation process of this system-level action, the actor parameter is no longer required. 