### PR TITLE
FIP-43 Made FIO Address optional for actions which do not require a FIO Address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ FIPs describe proposed changes to the FIO Protocol.
 |[FIP-40](fip-0040.md)|Enable specified accounts to register FIO Addresses on private FIO Domains|Accepted|
 |[FIP-41](fip-0041.md)|Enable token locking to existing accounts|Accepted|
 |[FIP-42](fip-0042.md)|Enable FIO Address and Domain registration in a single transaction|Accepted|
+|[FIP-43](fip-0043.md)|Made FIO Address optional for actions which do not require a FIO Address|Accepted|
 
 ## Contributing
 ### Review FIPs

--- a/fip-0043.md
+++ b/fip-0043.md
@@ -1,0 +1,50 @@
+---
+fip: 43
+title: Update get_fee validation
+status: Accepted
+type: Functionality
+author: Pawel Mastalerz <pawel@fioprotocol.io>
+created: 2022-03-17
+updated: 2022-03-17
+---
+
+# Abstract
+This FIP updates /get_fee to properly return a token fee for actions which are bundle-eligible, but do not require a FIO Address.
+
+## Modified getters
+|Endpoint|Description|
+|---|---|
+|/get_fee|Made FIO Address optional for actions which do not require a FIO Address.|
+
+# Motivation
+Currently the [/get_fee](https://developers.fioprotocol.io/pages/api/fio-api/#post-/get_fee) endpoint requires FIO Address for any action which is [bundle-eligible](https://developers.fioprotocol.io/docs/fio-protocol/fio-fees#fee-types). However, not all actions require a FIO Address and may instead be paid with a token fee. This makes it impossible to check a token fee if your FIO Address has enough bundled transaction. It should be possible to check token fee on any action which does not require a FIO Address.
+
+# Specification
+## Modified getters
+### get_fee
+#### Request
+Unchanged
+#### Processing
+Do not require FIO Address for the following fees:
+* /stake_fio_tokens
+* /unstake_fio_tokens
+* /vote_producer
+* /proxy_vote
+
+#### Response
+Unchanged
+
+# Rationale
+Change is required to properly communicate fees.
+
+# Implementation
+Consider how this list will be updated in the future when a new fee is added on an action which is bundle-eligible but does not require a FIO Address.
+
+# Backwards Compatibility
+No changes to requests/responses in existing actions or getters.
+
+# Future considerations
+None
+
+# Discussion link
+https://fioprotocol.atlassian.net/browse/WP-1135


### PR DESCRIPTION
Proposing as Accepted due to simple nature of FIP. 