### PR TITLE
remove api endpoint for unwrapdomain

### DIFF
--- a/fip-0017b.md
+++ b/fip-0017b.md
@@ -17,12 +17,12 @@ Proposed new actions:
 |Contract|Action|Endpoint|Description|
 |---|---|---|---|
 |fio.oracle|wrapdomain|wrap_fio_domain|Transfers FIO Domain to designated FIO account on the way to another chain.|
-|fio.oracle|unwrapdomain|transfer_fio_domain|Transfers FIO Domain to designated FIO account back from another chain.|
+|fio.oracle|unwrapdomain||Transfers FIO Domain to designated FIO account back from another chain.|
 
 Modified actions:
 |Contract|Action|Endpoint|Description|
 |---|---|---|---|
-|fio.address|xferdomain|wrap_fio_domain|Transfer of FIO Domain is now allowed even if the domain has expired.|
+|fio.address|xferdomain|transfer_fio_domain|Transfer of FIO Domain is now allowed even if the domain has expired.|
 
 # Motivation
 It is believed that the ability to wrap FIO Tokens and Domain NFTs will be beneficial to the FIO Community. It will open up new use cases for FIO Tokens and Domains such as:


### PR DESCRIPTION
This endpoint is not needed since it's a producer only action.